### PR TITLE
Get rid of null layer tooltips if undefined

### DIFF
--- a/geomoose/GeoMOOSE/Tab/Catalog.js
+++ b/geomoose/GeoMOOSE/Tab/Catalog.js
@@ -50,7 +50,11 @@ dojo.declare('GeoMOOSE.Tab._CatalogLayer', null, {
 		this.title = label;
 
 
-		var container = dojo.create('div', {title: tip}, p);
+		if (tip != null)
+			var container = dojo.create('div', {title: tip}, p);
+		else
+			var container = dojo.create('div', null, p);
+
 		this.div = container;
 
 		var title = dojo.create('div', {}, container);


### PR DESCRIPTION
If a tip was not defined for the layer whenever the user hovered over the layer in the catalog there would be a tooltip that said 'null'.
