### PR TITLE
Bug fix for activateLayerTool

### DIFF
--- a/geomoose/GeoMOOSE/UI/Toolbar.js
+++ b/geomoose/GeoMOOSE/UI/Toolbar.js
@@ -72,7 +72,7 @@ dojo.declare('GeoMOOSE.UI.Toolbar', [dijit.Toolbar], {
 	},
 
 	_layerToolAction: function() {
-		GeoMOOSE.activateLayerTool(this.action);
+		GeoMOOSE.activateLayerTool(this);
 	},
 
 	_addTool: function(parent, tool_xml, asMenuItem) {

--- a/geomoose/geomoose.js
+++ b/geomoose/geomoose.js
@@ -753,20 +753,18 @@ window.GeoMOOSE = {
 	 * Method: activateLayerTool
 	 * Activates a layer tool
 	 */
-	activateLayerTool: function(action) {
-		//return Application.getMapSource(layerName).getUrl();
+	activateLayerTool: function(toolbar) {
 		var active_map_source = GeoMOOSE.getActiveMapSource();
 		if(!GeoMOOSE.isDefined(active_map_source)) {
 			GeoMOOSE.error('There is no actively selected layer.  Please activate a layer from the catalog.');
 		} else {
 			var map_source = Application.getMapSource(active_map_source);
-			console.log(active_map_source, map_source, map_source.supports[action]);
-			if(map_source.supports[action] === true) {
+			if(map_source.supports[toolbar.action] === true) {
 				/* okay, let's go! */
-				if(this.selectable) {
-					this._deactivateTools();
+				if(toolbar.selectable) {
+					toolbar._deactivateTools();
 				}
-				map_source.controls[action].activate();
+				map_source.controls[toolbar.action].activate();
 			} else {
 				GeoMOOSE.error('The current active layer does not support your selected action.');
 			}


### PR DESCRIPTION
A recent change of moving activateLayerTool from GeoMOOSE/UI/Toolbar.js into geomoose.js has caused the sketch tools to not deactivate properly.  The scope of "this" is not the same.

To replicate the bug open the demo and draw a polygon.  Then switch to a point or line and both tools will still be active.

A change might also be needed for Popups.js.
