### PR TITLE
Mapsource defaults

### DIFF
--- a/geomoose/GeoMOOSE/ServiceInputTypes.js
+++ b/geomoose/GeoMOOSE/ServiceInputTypes.js
@@ -212,6 +212,22 @@ GeoMOOSE.Services.InputType.PrintInfo = OpenLayers.Class(GeoMOOSE.Services.Input
 		return dojo.toJson(print_info);
 	}
 });
+
+GeoMOOSE.Services.InputType.MapInfo = OpenLayers.Class(GeoMOOSE.Services.InputType, {
+	MAPBOOK_NAME: "map_info",
+
+	getValue: function() {
+		var map_info = {
+			extent: Map.getExtent().toArray(),
+			img_size: [ Map.getSize().w, Map.getSize().h ],
+			center: [ Map.getCenter().lon, Map.getCenter().lat ],
+			scale_denom: Map.getScale(),
+			resolution: Map.getResolution(),
+			projection: Map.getProjection().toString()
+		};
+		return dojo.toJson(map_info);
+	}
+});
 		
 GeoMOOSE.Services.InputType.User = OpenLayers.Class(GeoMOOSE.Services.InputType, {
 	MAPBOOK_NAME: "user",

--- a/geomoose/GeoMOOSE/Tab/Catalog.js
+++ b/geomoose/GeoMOOSE/Tab/Catalog.js
@@ -44,6 +44,19 @@ dojo.declare('GeoMOOSE.Tab._CatalogLayer', null, {
 
 	checkbox_id: '',
 
+	onRefreshMap: function() {
+		dojo.query('.catalog-layer-title').forEach(function(layer_title) {
+			var minscale = parseFloat(layer_title.getAttribute('data-minscale'));
+			var maxscale = parseFloat(layer_title.getAttribute('data-maxscale'));
+
+			if(GeoMOOSE.inScale(minscale, maxscale)) {
+				dojo.removeClass(layer_title, 'catalog-outscale');
+			} else {
+				dojo.addClass(layer_title, 'catalog-outscale');
+			}
+		});
+	},
+
 	constructor: function(parent_id, layer_xml, multiple, group_name) {
 		/* render ... */
 		var p = dojo.byId(parent_id);
@@ -52,10 +65,11 @@ dojo.declare('GeoMOOSE.Tab._CatalogLayer', null, {
 		var tip = layer_xml.getAttribute('tip');
 		var container;
 
-		if (tip != null)
+		if (tip != null) {
 			container = dojo.create('div', {title: tip}, p);
-		else
+		} else {
 			container = dojo.create('div', null, p);
+		}
 
 		this.div = container;
 
@@ -105,7 +119,19 @@ dojo.declare('GeoMOOSE.Tab._CatalogLayer', null, {
 		}));
 
 
-		var title = dojo.create('span', {'innerHTML' : label}, title);
+		var minscale = layer_xml.getAttribute('minscale');
+		var maxscale = layer_xml.getAttribute('maxscale');
+		/* store min/maxscale in the dom */
+		var label_span = dojo.create('span', {
+			'innerHTML' : label,
+			'data-minscale' : minscale,
+			'data-maxscale' : maxscale
+		}, title);
+		dojo.addClass(label_span, 'catalog-layer-title');
+
+		if(!GeoMOOSE.inScale(parseFloat(minscale),parseFloat(maxscale))) {
+			dojo.addClass(label_span, 'catalog-outscale');
+		}
 
 		/** Whew ... time to render controls ... yikes ... **/
 		var controls_id = GeoMOOSE.id();
@@ -232,6 +258,8 @@ dojo.declare('GeoMOOSE.Tab._CatalogLayer', null, {
 	},
 
 	updateDynamicLegend: function() {
+		this.onRefreshMap();
+
 		var legends_div = dojo.byId(this.legends_id);
 		while(legends_div.firstChild) { legends_div.removeChild(legends_div.firstChild); }
 

--- a/geomoose/GeoMOOSE/UI/CoordinateDisplay.js
+++ b/geomoose/GeoMOOSE/UI/CoordinateDisplay.js
@@ -36,7 +36,16 @@ dojo.declare('GeoMOOSE.UI.CoordinateDisplay', null, {
 		}, footer);
 
 		if(CONFIGURATION.coordinate_display.usng) {
-			this.usng = new USNG2();
+			var has_usng = true;
+			try {
+				eval('new USNG2()');
+			} catch(err) {
+				GeoMOOSE.error('usng display requested but USNG2 Library is not included.');
+				has_usng = false;
+			}
+			if(has_usng) {
+				this.usng = new USNG2();
+			}
 		}
 
 		/* wait for the mapbook to load and then finish setup */

--- a/geomoose/geomoose.js
+++ b/geomoose/geomoose.js
@@ -316,6 +316,21 @@ window.GeoMOOSE = {
 	},
 
 	/*
+	 * Method: inScale
+	 * Check whether a given min/maxscale is within the 
+	 *  current scale.
+	 */
+	inScale: function(minscale, maxscale) {
+		var scale = GeoMOOSE.getScale();
+		var def_minscale = GeoMOOSE.isDefined(minscale) && !isNaN(minscale);
+		var def_maxscale = GeoMOOSE.isDefined(maxscale) && !isNaN(maxscale);
+		if(!def_minscale && !def_maxscale) { return true; }
+		if(!def_maxscale && scale >= minscale) { return true; }
+		if(!def_minscale && scale <= maxscale) { return true; }
+		return (minscale <= scale && scale <= maxscale);
+	},
+
+	/*
 	 * Method: moveLayerUp
 	 * Move's a layer up on the visibility stack.
 	 *


### PR DESCRIPTION
Allow title attribute on map-source and map-source->layer to set default layer title (if not specified in catalog).  This is needed to specify a title for the Active Layers tab and helps with a DB generated mapbook.

Also allow status="on" to be set in the catalog.  This helps a lot with a DB generated mapbook.

If neither attribute is specified there no change to existing behavior.
