### PR TITLE
Add active layers tracking into HashTrack.js.

### DIFF
--- a/extensions/HashTrack.js
+++ b/extensions/HashTrack.js
@@ -30,7 +30,7 @@ THE SOFTWARE.
 HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 	center: null,
 	zoomLevel: null,
-
+	layers: null,
 
 	parseHashTag: function() {
 		var args = dojo.queryToObject(''+window.location.hash.substring(1));
@@ -44,7 +44,10 @@ HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 			this.center.lon = parseFloat(split[1]);
 			this.zoomLevel = parseFloat(split[2]);
 		}
-
+		this.layers = null;
+		if(args.l) {
+			this.layers = args.l.split(',');
+		}
 	},
 
 	init: function(map) {
@@ -55,13 +58,15 @@ HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 			});
 		}
 		map.events.register('moveend', this, this.mapMoved);
+		dojo.connect(Application, 'onLayersChange', dojo.hitch(this, this.mapMoved));
 	},
 
 	mapMoved: function() {
 		var center = Map.getCenter();
 		var zoom = Map.getZoom();
 		var position = center.lat + ',' + center.lon + ',' + zoom;
-		window.location.hash = '#xy='+position 
+		var layers = GeoMOOSE.getVisibleLayers().join(",");
+		window.location.hash = '#xy='+position+'&l='+layers;
 	},
 
 	load: function() {
@@ -71,6 +76,11 @@ HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 			this.parseHashTag();
 			if(this.center != null) {
 				Map.setCenter(this.center, this.zoomLevel);
+			}
+			if(this.layers != null) {
+ 				dojo.forEach(this.layers, function(val, idx) {
+					GeoMOOSE.turnLayerOn(val);
+				});
 			}
 		}));
 	},

--- a/extensions/HashTrack.js
+++ b/extensions/HashTrack.js
@@ -26,65 +26,122 @@ THE SOFTWARE.
  *  the map.  On startup, change the default extents to the stored location.
  *
  */
-
 HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
-	center: null,
-	zoomLevel: null,
-	layers: null,
+	map: null,  // reference to OpenLayers.Map
+	newHash: null, // the last thing we set the hash to.
 
+	/**
+	 * Method: parseHashTag
+	 * Parses the hash tag from the URL and updates the map state to match
+	 * the parameters.
+	 * 
+	 * Parameters:
+	 *  Parsed from window.location.hash:
+	 *    xy=[center x coordinate],[center y coordinate],[zoom level]
+	 *    l=[layer path],[layer path],...
+	 */
 	parseHashTag: function() {
+		//console.log("HashTrack: parseHashTag called");
+
+		// Avoid event loop where parseHashTag gets called as a result of updateHash
+		// setting window.location.hash thus causing a mapmove/layerchange...
+		if( this.newHash === window.location.hash ) {
+			//console.log("HashTrack: parseHashTag found no changes, exiting.");
+			return;
+		}
+
 		var args = dojo.queryToObject(''+window.location.hash.substring(1));
 
-		this.center = null;
 		if(args.xy) {
 			var split = args.xy.split(',');
 
-			this.center = new OpenLayers.LonLat();
-			this.center.lat = parseFloat(split[0]);
-			this.center.lon = parseFloat(split[1]);
-			this.zoomLevel = parseFloat(split[2]);
-		}
-		this.layers = null;
-		if(args.l) {
-			this.layers = args.l.split(',');
-		}
-	},
+			var center = new OpenLayers.LonLat();
+			center.lat = parseFloat(split[0]);
+			center.lon = parseFloat(split[1]);
+			var zoomLevel = parseFloat(split[2])
 
-	init: function(map) {
-		this.parseHashTag();
-		if(this.center != null) {
-			GeoMOOSE.register('onMapbookLoaded', this, function() {
-				map.setCenter(this.center, this.zoomLevel);
+			if(this.map) {
+				// this.map hould always be defined by the time this is called, but just to be safe.
+				this.map.setCenter(center, zoomLevel);
+			} else {
+				//console.log("HashTrack: Warning: parseHashTag called before Map is ready.");
+			}
+		}
+		if(args.on) {
+			var layers = args.on.split(';');
+
+			//console.log("HashTrack: parseHashTag found on layers: ", layers);
+			dojo.forEach(layers, function(val, idx) {
+				//console.log("HashTrack: parseHashTag turning on layer: " + val);
+				GeoMOOSE.turnLayerOn(val);
 			});
 		}
-		map.events.register('moveend', this, this.mapMoved);
-		dojo.connect(Application, 'onLayersChange', dojo.hitch(this, this.mapMoved));
+		if(args.off) {
+			var layers = args.off.split(';');
+
+			//console.log("HashTrack: parseHashTag found off layers: ", layers);
+			dojo.forEach(layers, function(val, idx) {
+				//console.log("HashTrack: parseHashTag turning off layer: " + val);
+				GeoMOOSE.turnLayerOff(val);
+			});
+		}
 	},
 
-	mapMoved: function() {
+	/**
+	 * Method: updateHash
+	 * Updates the hash parameters based on changes to the map state.
+	 * 
+	 * Parameters: none
+         * Side effects: Updates window.location.hash
+	 */
+	updateHash: function() {
+		//console.log("HashTrack: updateHash called");
+
 		var center = Map.getCenter();
 		var zoom = Map.getZoom();
 		var position = center.lat + ',' + center.lon + ',' + zoom;
-		var layers = GeoMOOSE.getVisibleLayers().join(",");
-		window.location.hash = '#xy='+position+'&l='+layers;
+
+		this.newHash = '#xy='+position;
+
+		var layer_changes = Application.getStatusDifferences();
+		if(layer_changes['on'].length > 0) {
+			this.newHash += '&on=' + layer_changes['on'].join(';');
+		}
+		if(layer_changes['off'].length > 0) {
+			this.newHash += '&off=' + layer_changes['off'].join(';');
+		}
+
+		// Don't update if no change.
+		if(window.location.hash !== this.newHash) {
+			//console.log("HashTrack: updateHash updating hash");
+			//console.log("Old: " + window.location.hash);
+			//console.log("New: " + this.newHash);
+			window.location.hash = this.newHash; // this causes a hashchange event
+		}
 	},
 
+	/**
+	 * Method: load
+	 * Called once when module is registered. Registers methods with GeoMOOSE events. 
+         */
 	load: function() {
-		GeoMOOSE.register('onMapCreated', this, this.init);
+		// Save the map (Don't assume window.Map).
+		GeoMOOSE.register('onMapCreated', this, function(map) {
+			this.map = map;
+		});
 
-		dojo.connect(window, 'hashchange', dojo.hitch(this, function() {
+		// Wait until mapbook is ready before moving map or messing with layers.
+		GeoMOOSE.register('onMapbookLoaded', this, function() {
+			// Make sure we parse the hash tag before we allow updates to the hash tag.
+			// Otherwise we can loose the initial passed in value.
 			this.parseHashTag();
-			if(this.center != null) {
-				Map.setCenter(this.center, this.zoomLevel);
-			}
-			if(this.layers != null) {
- 				dojo.forEach(this.layers, function(val, idx) {
-					GeoMOOSE.turnLayerOn(val);
-				});
-			}
-		}));
+
+			this.map.events.register('moveend', this, this.updateHash);
+			dojo.connect(Application, 'onLayersChange', dojo.hitch(this, this.updateHash));
+			dojo.connect(window, 'hashchange', dojo.hitch(this, this.parseHashTag));
+		});
 	},
-	
+
 	CLASS_NAME: "HashTrack"
 });
 

--- a/extensions/HashTrack.js
+++ b/extensions/HashTrack.js
@@ -37,8 +37,15 @@ HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 	 * 
 	 * Parameters:
 	 *  Parsed from window.location.hash:
+	 *    xy: map center position and zoom level e.g:
 	 *    xy=[center x coordinate],[center y coordinate],[zoom level]
-	 *    l=[layer path],[layer path],...
+	 *
+	 *    on, off: Semicolon separated lists of layer paths to turn on
+	 *             or off.  Starting with the defaults in the mapbook, first
+	 *             the on list is used to turn on layers then the off list
+	 *             is used to turn off layers. e.g:
+	 *    on=[layer path];[layer path];...
+	 *    off=[layer path];[layer path];...
 	 */
 	parseHashTag: function() {
 		//console.log("HashTrack: parseHashTag called");
@@ -92,7 +99,7 @@ HashTrack = new OpenLayers.Class(GeoMOOSE.UX.Extension, {
 	 * Updates the hash parameters based on changes to the map state.
 	 * 
 	 * Parameters: none
-         * Side effects: Updates window.location.hash
+	 * Side effects: Updates window.location.hash
 	 */
 	updateHash: function() {
 		//console.log("HashTrack: updateHash called");

--- a/geomoose/GeoMOOSE/Layer.js
+++ b/geomoose/GeoMOOSE/Layer.js
@@ -162,6 +162,16 @@ dojo.declare('GeoMOOSE.Layer', null, {
 				paths.push(src);
 			}
 			GeoMOOSE.changeLayerVisibility(paths, stat);
+
+			for(var path in this.paths) {
+			    var mapsource = Application.getMapSource(path);
+			    var parts;
+			    var layer;
+			    if(mapsource && (parts = path.split('/')) && parts[1] 
+					&& (layer = mapsource.getLayerByName(parts[1]))) {
+				layer.initial_on = stat;
+			    }
+			}
 		}
 	},
 


### PR DESCRIPTION
The intended purpose is to be able to save a map view (position and layers) as a URL and either send it to someone else (e.g. email) or restore your session (bookmark).

This works by adding tracking of the active layers to the HashTrack.js extension.  Similar to how map positioning tracking works, it adds a l=[path],[path],... parameter which tracks the active layers as they are turned on/off in GeoMoose.  On startup it turns on any layer listed in the l parameter.  

Possible future enhancements:
* On startup, it does not turn off layers that default on in the mapbook.
* Add a parameter to save sketch layers as well (this may be too large to fit into the URL comfortably).

Update:
* Turning layers on and off has been implemented with the on and off parameters in the same way as GeoMOOSE.getBookmarkUrl().  This replaces the "l" parameter listed above.